### PR TITLE
Support promise resolver for Promise compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ iP2.reject('World')
 
 ## API
 
-### `const ip = new InvertedPromise()`
+### `const ip = new InvertedPromise([resolver])`
 
 Create a new `InvertedPromise`
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
-module.exports = function InvertedPromise () {
+module.exports = function InvertedPromise (resolver) {
   var res
   var rej
 
   var p = new Promise((resolve, reject) => {
     res = resolve
     rej = reject
+
+    if (typeof resolver === 'function') {
+      resolver(resolve, reject)
+    }
   })
 
   p.resolve = res

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {},
   "devDependencies": {
     "standard": "^14.3.4",
     "tape": "^5.0.1"

--- a/test.js
+++ b/test.js
@@ -54,3 +54,34 @@ test('resolve then reject', function (assert) {
   p.resolve('ok')
   p.reject('ok')
 })
+
+test('resolve in resolver', function (assert) {
+  assert.plan(1)
+  const p = new InvertedPromise((resolve) => {
+    resolve(123)
+  })
+
+  p.then(value => {
+    assert.ok(value === 123)
+  }).catch(err => {
+    assert.error(err)
+  })
+
+  p.resolve(456)
+})
+
+test('reject in resolver', function (assert) {
+  assert.plan(1)
+  const p = new InvertedPromise((resolve, reject) => {
+    reject(new Error('oops'))
+  })
+
+  p.then(value => {
+    // unreachable
+    assert.notOk(value)
+  }).catch(err => {
+    assert.ok(err && err.message === 'oops')
+  })
+
+  p.reject(new Error('ouch'))
+})


### PR DESCRIPTION
This PR allows the `InvertedPromise` class to maintain compatibility with the `Promise` class by supporting the `resolver` function given to the `Promise` constructor.